### PR TITLE
Remove const keyword from RunnerStatus enum

### DIFF
--- a/src/conductor/types/RunnerStatus.ts
+++ b/src/conductor/types/RunnerStatus.ts
@@ -1,4 +1,4 @@
-export const enum RunnerStatus {
+export enum RunnerStatus {
     ONLINE,     // Runner is online
     EVAL_READY, // Evaluator is ready
     RUNNING,    // I am running some code


### PR DESCRIPTION
Removed const keyword from the RunnerStatus enum so it can be refrenced outside conductor