### PR TITLE
Modules: Switch Module Closures to be `AsyncGenerator`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Thus, evaluators are responsible for providing functions to allow modules to rea
 Each of the data types passed as identifier have functions to create an instance of that data type,
 as well as read and write data to it (or call it, in the case of closures). See `conductor/types/IDataHandler`.
 
+In the case of closures, the `closure_call` and `closure_call_unchecked` return `AsyncGenerator`s. In the case of CSE machines, yielding a closure call to a CSE closure would allow the module function to defer the execution until the closure's return value is executed.
+
 ### Standard library
 
 A standard library of functions must be made available to modules. See `conductor/stdlib` for sample implementations.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Thus, evaluators are responsible for providing functions to allow modules to rea
 Each of the data types passed as identifier have functions to create an instance of that data type,
 as well as read and write data to it (or call it, in the case of closures). See `conductor/types/IDataHandler`.
 
-In the case of closures, the `closure_call` and `closure_call_unchecked` return `AsyncGenerator`s. In the case of CSE machines, yielding a closure call to a CSE closure would allow the module function to defer the execution until the closure's return value is executed.
+In the case of closures, the `closure_call` and `closure_call_unchecked` return `AsyncGenerator`s. In the case of CSE machines, yielding a closure call to a CSE closure would allow the module function to defer the execution until the closure is executed and its return value is available.
 
 ### Standard library
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conductor",
   "packageManager": "yarn@4.6.0",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/conductor/stdlib/list/accumulate.ts
+++ b/src/conductor/stdlib/list/accumulate.ts
@@ -11,12 +11,11 @@ import { DataType, type IDataHandler, type TypedValue } from "../../types"
  * @param resultType The (expected) type of the result.
  * @returns A Promise resolving to the result of accumulating the Closure over the List.
  */
-export async function accumulate<T extends Exclude<DataType, DataType.VOID>>(this: IDataHandler, op: TypedValue<DataType.CLOSURE, T>, initial: TypedValue<T>, sequence: TypedValue<DataType.LIST>, resultType: T): Promise<TypedValue<T>> {
+export async function* accumulate<T extends Exclude<DataType, DataType.VOID>>(this: IDataHandler, op: TypedValue<DataType.CLOSURE, T>, initial: TypedValue<T>, sequence: TypedValue<DataType.LIST>, resultType: T): AsyncGenerator<void, TypedValue<T>, undefined> {
     const vec = await this.list_to_vec(sequence);
     let result = initial;
     for (let i = vec.length - 1; i >= 0; --i) {
-        result = await this.closure_call(op, [vec[i], result], resultType);
+        result = yield* this.closure_call(op, [vec[i], result], resultType);
     }
-
     return result;
 }

--- a/src/conductor/stdlib/list/accumulate.ts
+++ b/src/conductor/stdlib/list/accumulate.ts
@@ -9,7 +9,7 @@ import { DataType, type IDataHandler, type TypedValue } from "../../types"
  * @param initial The initial typed value (that is, the result of accumulating an empty List).
  * @param sequence The List to be accumulated over.
  * @param resultType The (expected) type of the result.
- * @returns A Promise resolving to the result of accumulating the Closure over the List.
+ * @returns An AsyncGenerator resolving to the result of accumulating the Closure over the List.
  */
 export async function* accumulate<T extends Exclude<DataType, DataType.VOID>>(this: IDataHandler, op: TypedValue<DataType.CLOSURE, T>, initial: TypedValue<T>, sequence: TypedValue<DataType.LIST>, resultType: T): AsyncGenerator<void, TypedValue<T>, undefined> {
     const vec = await this.list_to_vec(sequence);

--- a/src/conductor/types/moduleInterface/ExternCallable.ts
+++ b/src/conductor/types/moduleInterface/ExternCallable.ts
@@ -5,4 +5,4 @@ type DataTypeMap<T extends readonly [...DataType[]]> = {
     [Idx in keyof T]: TypedValue<T[Idx]>
 };
 
-export type ExternCallable<Arg extends readonly DataType[], Ret extends DataType> = (...args: DataTypeMap<Arg>) => TypedValue<Ret> | Promise<TypedValue<Ret>>;
+export type ExternCallable<Arg extends readonly DataType[], Ret extends DataType> = (...args: DataTypeMap<Arg>) => AsyncGenerator<void, TypedValue<Ret>, undefined>;

--- a/src/conductor/types/moduleInterface/IDataHandler.ts
+++ b/src/conductor/types/moduleInterface/IDataHandler.ts
@@ -143,7 +143,7 @@ export interface IDataHandler {
      * @param c The Closure to be called.
      * @param args An array of typed arguments to be passed to the Closure.
      * @param returnType The expected type of the returned value.
-     * @returns A promise to the returned typed value.
+     * @returns An AsyncGenerator which returns the returned typed value.
      */
     closure_call<T extends DataType>(c: TypedValue<DataType.CLOSURE, T>, args: TypedValue<DataType>[], returnType: T): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
 
@@ -151,7 +151,7 @@ export interface IDataHandler {
      * Calls a Closure of known return type.
      * @param c The Closure to be called.
      * @param args An array of typed arguments to be passed to the Closure.
-     * @returns A promise to the returned typed value.
+     * @returns An AsyncGenerator which returns the returned typed value.
      */
     closure_call_unchecked<T extends DataType>(c: TypedValue<DataType.CLOSURE, T>, args: TypedValue<DataType>[]): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
 

--- a/src/conductor/types/moduleInterface/IDataHandler.ts
+++ b/src/conductor/types/moduleInterface/IDataHandler.ts
@@ -145,7 +145,7 @@ export interface IDataHandler {
      * @param returnType The expected type of the returned value.
      * @returns A promise to the returned typed value.
      */
-    closure_call<T extends DataType>(c: TypedValue<DataType.CLOSURE, T>, args: TypedValue<DataType>[], returnType: T): Promise<TypedValue<NoInfer<T>>>;
+    closure_call<T extends DataType>(c: TypedValue<DataType.CLOSURE, T>, args: TypedValue<DataType>[], returnType: T): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
 
     /**
      * Calls a Closure of known return type.
@@ -153,7 +153,7 @@ export interface IDataHandler {
      * @param args An array of typed arguments to be passed to the Closure.
      * @returns A promise to the returned typed value.
      */
-    closure_call_unchecked<T extends DataType>(c: TypedValue<DataType.CLOSURE, T>, args: TypedValue<DataType>[]): Promise<TypedValue<NoInfer<T>>>;
+    closure_call_unchecked<T extends DataType>(c: TypedValue<DataType.CLOSURE, T>, args: TypedValue<DataType>[]): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
 
     /**
      * Asserts the arity of a Closure.
@@ -208,6 +208,6 @@ export interface IDataHandler {
     list(...elements: TypedValue<DataType>[]): Promise<TypedValue<DataType.LIST>>;
     is_list(xs: TypedValue<DataType.LIST>): Promise<boolean>;
     list_to_vec(xs: TypedValue<DataType.LIST>): Promise<TypedValue<DataType>[]>;
-    accumulate<T extends Exclude<DataType, DataType.VOID>>(op: TypedValue<DataType.CLOSURE, T>, initial: TypedValue<T>, sequence: TypedValue<DataType.LIST>, resultType: T): Promise<TypedValue<T>>;
+    accumulate<T extends Exclude<DataType, DataType.VOID>>(op: TypedValue<DataType.CLOSURE, T>, initial: TypedValue<T>, sequence: TypedValue<DataType.LIST>, resultType: T): AsyncGenerator<void, TypedValue<T>, undefined>;
     length(xs: TypedValue<DataType.LIST>): Promise<number>;
 }


### PR DESCRIPTION
This PR migrates foreign functions in the module types to represent `AsyncGenerator`s instead of raw functions. 

## Rationale
This has been implemented to solve a re-entrancy issue for module function execution in CSE machines. If a module function needs to call a CSE closure, the CSE machine is stalled by the module function and cannot evaluate the closure

With the new update, the `AsyncGenerator` allows the module function to `yield` when it needs to evaluate a CSE closure.
For example,

```ts
function f(x: TypedValue<DataType.CLOSURE>): AsyncGenerator<void, TypedValue<DataType.VOID>, undefined> {
    // NOTE: yield* is used since it delegates yields to the data handler on the runner side to decide when 
    // the closure needs to yield (aka, is a CSE closure)
    yield* evaluator.closure_call_unchecked(x, []);
    return mVoid();
}
```