### PR TITLE
fix(runner): one-shot evaluator lifecycle with RUNNING/STOPPED/ERROR status

### DIFF
--- a/src/conductor/runner/BasicEvaluator.ts
+++ b/src/conductor/runner/BasicEvaluator.ts
@@ -1,17 +1,23 @@
 import { ConductorInternalError } from "../../common/errors";
+import { RunnerStatus } from "../types";
 import type { IEvaluator, IRunnerPlugin } from "./types";
 
 export abstract class BasicEvaluator implements IEvaluator {
     readonly conductor: IRunnerPlugin;
 
     async startEvaluator(entryPoint: string): Promise<void> {
-        const initialChunk = await this.conductor.requestFile(entryPoint);
-        if (!initialChunk) throw new ConductorInternalError("Cannot load entrypoint file");
-        this.conductor.sendResult(await this.evaluateFile(entryPoint, initialChunk));
-        while (true) {
-            const chunk = await this.conductor.requestChunk();
-            this.conductor.sendResult(await this.evaluateChunk(chunk));
+        try {
+            const initialChunk = await this.conductor.requestFile(entryPoint);
+            if (!initialChunk) throw new ConductorInternalError("Cannot load entrypoint file");
+            this.conductor.updateStatus(RunnerStatus.RUNNING, true);
+            this.conductor.sendResult(await this.evaluateFile(entryPoint, initialChunk));
+        } catch (e) {
+            this.conductor.updateStatus(RunnerStatus.RUNNING, false);
+            this.conductor.updateStatus(RunnerStatus.ERROR, true);
+            throw e;
         }
+        this.conductor.updateStatus(RunnerStatus.RUNNING, false);
+        this.conductor.updateStatus(RunnerStatus.STOPPED, true);
     }
 
     /**

--- a/src/conductor/runner/RunnerPlugin.ts
+++ b/src/conductor/runner/RunnerPlugin.ts
@@ -39,8 +39,14 @@ export class RunnerPlugin implements IRunnerPlugin {
             console.error(`Host expects at least protocol version ${message.data.minVersion}, but we are on version ${Constant.PROTOCOL_VERSION}`);
             this.__conduit.terminate();
         }],
-        [ServiceMessageType.ENTRY, function entryServiceHandler(this: RunnerPlugin, message: EntryServiceMessage) {
-            this.__evaluator.startEvaluator(message.data);
+        [ServiceMessageType.ENTRY, async function entryServiceHandler(this: RunnerPlugin, message: EntryServiceMessage) {
+            try {
+                await this.__evaluator.startEvaluator(message.data);
+            } catch (_e) {
+                // BasicEvaluator already sends RunnerStatus.ERROR; this is a safety net for
+                // evaluator subclasses that override startEvaluator without the same guarantee.
+                this.updateStatus(RunnerStatus.ERROR, true);
+            }
         }]
     ]);
 


### PR DESCRIPTION
## Summary

- **`BasicEvaluator.startEvaluator`**: removes the infinite `while (true)` REPL loop. Each evaluation is now one-shot — the evaluator runs the file, then exits cleanly. Status signals emitted:
  - `RUNNING → true` before evaluation begins
  - `RUNNING → false` + `STOPPED → true` on success
  - `RUNNING → false` + `ERROR → true` on failure (error is re-thrown for the caller)
- **`RunnerPlugin` ENTRY handler**: made `async` so `startEvaluator` is properly awaited. Evaluator subclasses that override `startEvaluator` without the RUNNING/ERROR guarantee still get an ERROR status emitted as a safety net.

## Why one-shot

The continuous REPL loop required the host to terminate the worker to stop execution, which destroyed tab state (CSE machine, stepper, etc.) on every run. One-shot lets the conductor instance stay alive across runs — only the evaluator lifecycle is scoped to a single evaluation.

## Test plan

- [ ] Run a Source/Python program — CSE machine tab persists after run completes
- [ ] Trigger a runtime error — host sees ERROR status and can display the error
- [ ] Stop button mid-run — worker termination still works as a fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)