### PR TITLE
feat(host): add receiveResult callback to BasicHostPlugin

### DIFF
--- a/src/common/errors/ErrorType.ts
+++ b/src/common/errors/ErrorType.ts
@@ -1,4 +1,4 @@
-export const enum ErrorType {
+export enum ErrorType {
     UNKNOWN = "__unknown",
     INTERNAL = "__internal",
     EVALUATOR = "__evaluator",

--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -100,7 +100,7 @@ export abstract class BasicHostPlugin implements IHostPlugin {
             this.receiveStatusUpdate?.(status, isActive);
         });
 
-        resultChannel.subscribe((resultMessage: IResultMessage) => this.receiveResult?.(resultMessage.result));
+        resultChannel?.subscribe((resultMessage: IResultMessage) => this.receiveResult?.(resultMessage.result));
 
         makeRpc<IHostPluginRpc, {}>(pluginChannel, {
             $requestLoadPlugin: this.requestLoadPlugin.bind(this),

--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -3,7 +3,7 @@ import type { ConductorError } from "../../common/errors";
 import { importExternalPlugin } from "../../common/util";
 import { checkIsPluginClass, type PluginClass, makeRpc, type IChannel, type IConduit, type IPlugin } from "../../conduit";
 import { InternalPluginId, InternalChannelName } from "../strings";
-import { type IChunkMessage, type IServiceMessage, RunnerStatus, ServiceMessageType, HelloServiceMessage, AbortServiceMessage, EntryServiceMessage, type Chunk, type IErrorMessage, type IStatusMessage, type IIOMessage } from "../types";
+import { type IChunkMessage, type IServiceMessage, RunnerStatus, ServiceMessageType, HelloServiceMessage, AbortServiceMessage, EntryServiceMessage, type Chunk, type IErrorMessage, type IResultMessage, type IStatusMessage, type IIOMessage } from "../types";
 import type { IHostFileRpc, IHostPlugin, IHostPluginRpc } from "./types";
 
 @checkIsPluginClass
@@ -63,6 +63,8 @@ export abstract class BasicHostPlugin implements IHostPlugin {
 
     receiveStatusUpdate?(status: RunnerStatus, isActive: boolean): void;
 
+    receiveResult?(result: any): void;
+
     registerPlugin<Arg extends any[], T extends IPlugin>(pluginClass: PluginClass<Arg, T>, ...arg: Arg): NoInfer<T> {
         return this.__conduit.registerPlugin(pluginClass, ...arg);
     }
@@ -76,8 +78,8 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         return this.registerPlugin(pluginClass as any, ...arg);
     }
 
-    static readonly channelAttach = [InternalChannelName.FILE, InternalChannelName.CHUNK, InternalChannelName.SERVICE, InternalChannelName.STANDARD_IO, InternalChannelName.ERROR, InternalChannelName.STATUS, InternalChannelName.PLUGIN];
-    constructor(conduit: IConduit, [fileChannel, chunkChannel, serviceChannel, ioChannel, errorChannel, statusChannel, pluginChannel]: IChannel<any>[]) {
+    static readonly channelAttach = [InternalChannelName.FILE, InternalChannelName.CHUNK, InternalChannelName.SERVICE, InternalChannelName.STANDARD_IO, InternalChannelName.ERROR, InternalChannelName.STATUS, InternalChannelName.PLUGIN, InternalChannelName.RESULT];
+    constructor(conduit: IConduit, [fileChannel, chunkChannel, serviceChannel, ioChannel, errorChannel, statusChannel, pluginChannel, resultChannel]: IChannel<any>[]) {
         this.__conduit = conduit;
 
         makeRpc<IHostFileRpc, {}>(fileChannel, {
@@ -97,6 +99,8 @@ export abstract class BasicHostPlugin implements IHostPlugin {
             this.__status.set(status, isActive);
             this.receiveStatusUpdate?.(status, isActive);
         });
+
+        resultChannel.subscribe((resultMessage: IResultMessage) => this.receiveResult?.(resultMessage.result));
 
         makeRpc<IHostPluginRpc, {}>(pluginChannel, {
             $requestLoadPlugin: this.requestLoadPlugin.bind(this),

--- a/src/conductor/host/types/IHostPlugin.ts
+++ b/src/conductor/host/types/IHostPlugin.ts
@@ -92,6 +92,12 @@ export interface IHostPlugin extends IPlugin {
     receiveStatusUpdate?(status: RunnerStatus, isActive: boolean): void;
 
     /**
+     * An event handler called when an evaluation result is received.
+     * @param result The result of the evaluation.
+     */
+    receiveResult?(result: any): void;
+
+    /**
      * Registers a plugin with the conduit.
      * @param pluginClass The plugin class to be registered.
      * @param arg Arguments to be passed to pluginClass' constructor.


### PR DESCRIPTION
## Summary

**CAN ONLY BE merged after #30**

- Adds `InternalChannelName.RESULT` to `BasicHostPlugin.channelAttach`
- Subscribes to the result channel in the constructor and calls `this.receiveResult?.(result)` on each message, matching the pattern used by `receiveError` and `receiveStatusUpdate`
- Adds `receiveResult?(result: any): void` to `IHostPlugin`

## Why this is needed

The runner's `RunnerPlugin` already sends evaluation results on the `RESULT` channel (added in an earlier PR). The host side (`BasicHostPlugin`) had no corresponding support — it wasn't attached to the channel at all. Host apps that needed evaluation results had to work around this by manually appending `'__result'` to `channelAttach` and searching for the channel by name in their constructor, bypassing the normal plugin API entirely.

With this change, host apps (like the Source Academy frontend's `BrowserHostPlugin`) can simply override `receiveResult` to get results the same way they override `receiveError` or `receiveStatusUpdate`.