### PR TITLE
fix: remove const keyword from all remaining exported enums

### DIFF
--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -1,4 +1,4 @@
-export const enum Constant {
+export enum Constant {
     PROTOCOL_VERSION = 0,
     PROTOCOL_MIN_VERSION = 0,
     SETUP_MESSAGES_BUFFER_SIZE = 10,

--- a/src/conductor/strings/InternalChannelName.ts
+++ b/src/conductor/strings/InternalChannelName.ts
@@ -1,4 +1,4 @@
-export const enum InternalChannelName {
+export enum InternalChannelName {
     CHUNK = "__chunk",
     FILE = "__file_rpc",
     SERVICE = "__service",

--- a/src/conductor/strings/InternalPluginId.ts
+++ b/src/conductor/strings/InternalPluginId.ts
@@ -1,4 +1,4 @@
-export const enum InternalPluginId {
+export enum InternalPluginId {
     HOST_MAIN = "__host_main",
     RUNNER_MAIN = "__runner_main"
 };

--- a/src/conductor/types/ServiceMessageType.ts
+++ b/src/conductor/types/ServiceMessageType.ts
@@ -1,4 +1,4 @@
-export const enum ServiceMessageType {
+export enum ServiceMessageType {
     /** A handshake message. See `HelloServiceMessage`. */
     HELLO = 0,
 


### PR DESCRIPTION
## Summary

Follows up on #25 (`RunnerStatus`) and #33 (`ErrorType`) by removing `const` from the four remaining exported enums:

- `InternalChannelName`
- `InternalPluginId`
- `ServiceMessageType`
- `Constant`

## Why

`const enum` values are completely erased from emitted JS. Consumers that compile with `isolatedModules` (rollup, esbuild, Vite — all modern bundlers) cannot inline `const enum` values from external packages, so any runtime access returns `undefined` instead of the expected string/number. This was flagged as a review comment on #33.

None of these enums are currently imported by external consumers, so this is a correctness pre-emption rather than a live bug fix — but it keeps the codebase consistent and safe as the ecosystem grows.