### PR TITLE
Add input-request signal to the IO protocol for input()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conductor",
   "packageManager": "yarn@4.6.0",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -93,8 +93,10 @@ export abstract class BasicHostPlugin implements IHostPlugin {
 
         this.__ioChannel = ioChannel;
         ioChannel.subscribe((ioMessage: IIOMessage) => {
-            if (ioMessage.kind === "inputRequest") {
-                this.receiveInputRequest?.(ioMessage.message);
+            // Fall back to receiveOutput for hosts that don't implement receiveInputRequest, so
+            // the prompt is still surfaced somewhere instead of being silently dropped.
+            if (ioMessage.kind === "inputRequest" && this.receiveInputRequest) {
+                this.receiveInputRequest(ioMessage.message);
             } else {
                 this.receiveOutput?.(ioMessage.message);
             }

--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -55,6 +55,8 @@ export abstract class BasicHostPlugin implements IHostPlugin {
 
     receiveOutput?(message: string): void;
 
+    receiveInputRequest?(prompt: string): void;
+
     receiveError?(message: ConductorError): void;
 
     isStatusActive(status: RunnerStatus): boolean {
@@ -90,7 +92,13 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         this.__serviceChannel = serviceChannel;
 
         this.__ioChannel = ioChannel;
-        ioChannel.subscribe((ioMessage: IIOMessage) => this.receiveOutput?.(ioMessage.message));
+        ioChannel.subscribe((ioMessage: IIOMessage) => {
+            if (ioMessage.kind === "inputRequest") {
+                this.receiveInputRequest?.(ioMessage.message);
+            } else {
+                this.receiveOutput?.(ioMessage.message);
+            }
+        });
 
         errorChannel.subscribe((errorMessage: IErrorMessage) => this.receiveError?.(errorMessage.error));
 

--- a/src/conductor/host/types/IHostPlugin.ts
+++ b/src/conductor/host/types/IHostPlugin.ts
@@ -59,6 +59,12 @@ export interface IHostPlugin extends IPlugin {
      */
     receiveOutput?(message: string): void;
 
+    /**
+     * An event handler called when the runner requests input on standard-input.
+     * @param prompt The prompt to show the user requesting the input, if any.
+     */
+    receiveInputRequest?(prompt: string): void;
+
     // /**
     //  * Request for some output on standard-error.
     //  * @returns A promise resolving to the error received.

--- a/src/conductor/runner/RunnerPlugin.ts
+++ b/src/conductor/runner/RunnerPlugin.ts
@@ -59,7 +59,10 @@ export class RunnerPlugin implements IRunnerPlugin {
         return (await this.__chunkQueue.receive()).chunk;
     }
 
-    async requestInput(): Promise<string> {
+    async requestInput(prompt?: string): Promise<string> {
+        if (prompt !== undefined) {
+            this.__ioQueue.send({ message: prompt, kind: "inputRequest" });
+        }
         const { message } = await this.__ioQueue.receive();
         return message;
     }

--- a/src/conductor/runner/RunnerPlugin.ts
+++ b/src/conductor/runner/RunnerPlugin.ts
@@ -60,9 +60,9 @@ export class RunnerPlugin implements IRunnerPlugin {
     }
 
     async requestInput(prompt?: string): Promise<string> {
-        if (prompt !== undefined) {
-            this.__ioQueue.send({ message: prompt, kind: "inputRequest" });
-        }
+        // Always notify the host that input is being requested, even with no prompt text -
+        // otherwise the runner blocks with no signal at all reaching the host.
+        this.__ioQueue.send({ message: prompt ?? "", kind: "inputRequest" });
         const { message } = await this.__ioQueue.receive();
         return message;
     }

--- a/src/conductor/runner/types/IRunnerPlugin.ts
+++ b/src/conductor/runner/types/IRunnerPlugin.ts
@@ -19,9 +19,10 @@ export interface IRunnerPlugin extends IPlugin {
 
     /**
      * Request for some input on standard-input.
+     * @param prompt An optional prompt to show the user requesting the input.
      * @returns A promise resolving to the input received.
      */
-    requestInput(): Promise<string>;
+    requestInput(prompt?: string): Promise<string>;
 
     /**
      * Try to request for some input on standard-input.

--- a/src/conductor/types/IIOMessage.ts
+++ b/src/conductor/types/IIOMessage.ts
@@ -1,4 +1,10 @@
 export interface IIOMessage {
     // stream: number;
     message: string;
+
+    /**
+     * Distinguishes a runner-initiated request for input (carrying an optional prompt string
+     * in `message`) from a plain standard-output chunk. Absent/"output" for ordinary output.
+     */
+    kind?: "output" | "inputRequest";
 }


### PR DESCRIPTION
## Summary
- Adds an optional `prompt` to `IRunnerPlugin.requestInput()`, sent as a new `IIOMessage.kind: "inputRequest"`-tagged message over the existing IO channel before the runner blocks waiting for a reply.
- Adds `IHostPlugin.receiveInputRequest?(prompt: string)`, dispatched by `BasicHostPlugin` based on the new `kind` discriminator (falls back to the existing `receiveOutput` for plain output messages).
- Additive/backward-compatible: existing zero-arg `requestInput()` calls and hosts that don't implement `receiveInputRequest` keep working unchanged.

This lets a host (e.g. a browser IDE) show a popup for the prompt before the runner blocks, instead of the runner just hanging with no signal to the host at all — motivated by [source-academy/py-slang#190](https://github.com/source-academy/py-slang/issues/190), where `print(input("..."))` hangs because nothing ever answers `requestInput()`.

Version bumped 0.5.0 → 0.6.0.

## Test plan
- [x] `yarn build` succeeds cleanly (rollup, no errors)
- [x] Manually verified `input-request`-tagged messages are dispatched to `receiveInputRequest` and plain output still reaches `receiveOutput`, via a downstream consumer (py-slang) built against this branch
- [ ] No automated test suite exists in this repo yet to extend (`find . -iname "*.test.ts"` returns nothing under `src/`)

Downstream consumers (source-academy/py-slang, source-academy/frontend) have branches ready that depend on this change via a temporary `portal:` dev pin, to be repinned once this is released.