### PR TITLE
Bind exported module methods to their instance in BaseModulePlugin

### DIFF
--- a/src/conductor/module/BaseModulePlugin.ts
+++ b/src/conductor/module/BaseModulePlugin.ts
@@ -21,7 +21,12 @@ export abstract class BaseModulePlugin implements IModulePlugin {
         for (const name of this.exportedNames) {
             const m = this[name] as ExternCallable<any, any> & {signature?: IFunctionSignature<any, any>};
             if (!m.signature || typeof m !== "function" || typeof name !== "string") throw new ConductorInternalError(`'${String(name)}' is not an exportable method`);
-            const c = await this.evaluator.closure_make(m.signature, m);
+            // Evaluators invoke the registered closure as a bare function (e.g.
+            // `closure.func(...args)`), so `m` must be bound to this instance here —
+            // otherwise `this` inside the method body is undefined the moment it's called.
+            const boundMethod = m.bind(this) as typeof m;
+            boundMethod.signature = m.signature;
+            const c = await this.evaluator.closure_make(m.signature, boundMethod);
             this.exports.push({
                 symbol: name,
                 value: c,


### PR DESCRIPTION
## Description

`BaseModulePlugin.initialise()` registers each exported method with `closure_make` as a detached function reference (`this[name]`), without binding it to the instance:

```ts
const m = this[name] as ExternCallable<any, any> & {signature?: IFunctionSignature<any, any>};
...
const c = await this.evaluator.closure_make(m.signature, m);
```

Every evaluator invokes the resulting closure as a bare function (`closure.func(...args)`), so `this` inside the method body is `undefined` the moment it's called for real — any exported method that touches `this.evaluator` or other instance state breaks immediately once a real evaluator (not a mock that happens to call it bound) drives it.

Fix: bind `m` to the instance before registering it, and copy over the `.signature` property the `moduleMethod` decorator attaches (`Function.prototype.bind()` alone doesn't copy it, and `initialise()`'s own signature check depends on it).

## Context

Confirmed via an integration test that loads a real compiled module bundle and drives it through py-slang's actual evaluator (`closure_call_unchecked`, not a mock): every exported method that reads `this.evaluator` throws `Cannot read properties of undefined` until this is fixed.

`repeat` and `rune` (#765) both already work around this per-module with an identical `__bindExportedMethods()` helper called from their own constructors. Fixing it here means future modules don't need to remember that boilerplate. This change is backwards-compatible with that workaround — a module that already pre-binds its methods just gets bound twice (harmless), so this doesn't force a fix on `repeat`/`rune`'s side; their `__bindExportedMethods()` just becomes dead code they can strip whenever convenient.