### PR TITLE
Support exclusive number-range bounds

### DIFF
--- a/src/common/errors/EvaluatorNumberRangeError.ts
+++ b/src/common/errors/EvaluatorNumberRangeError.ts
@@ -1,21 +1,29 @@
 import { EvaluatorParameterTypeError } from "./EvaluatorParameterTypeError";
 
 export interface NumberRangeOptions {
-    /** Minimum allowable value (inclusive). Omit to not perform a minimum check. */
+    /** Minimum allowable value. Inclusive unless `minExclusive` is set. Omit to not perform a minimum check. */
     min?: number;
-    /** Maximum allowable value (inclusive). Omit to not perform a maximum check. */
+    /** Maximum allowable value. Inclusive unless `maxExclusive` is set. Omit to not perform a maximum check. */
     max?: number;
+    /** `false` by default. Set to `true` to reject `value === min`. Has no effect if `min` is omitted. */
+    minExclusive?: boolean;
+    /** `false` by default. Set to `true` to reject `value === max`. Has no effect if `max` is omitted. */
+    maxExclusive?: boolean;
     /** `true` by default. Set to `false` to allow non-integer values. */
     integer?: boolean;
 }
 
 function describeNumberRange(options: NumberRangeOptions | string): string {
     if (typeof options === "string") return options;
-    const { min, max, integer = true } = options;
+    const { min, max, minExclusive = false, maxExclusive = false, integer = true } = options;
     const type = integer ? "integer" : "number";
-    if (min !== undefined && max !== undefined) return `${type} ∈ [${min}, ${max}]`;
-    if (min !== undefined) return `${type} ≥ ${min}`;
-    if (max !== undefined) return `${type} ≤ ${max}`;
+    if (min !== undefined && max !== undefined) {
+        const open = minExclusive ? "(" : "[";
+        const close = maxExclusive ? ")" : "]";
+        return `${type} ∈ ${open}${min}, ${max}${close}`;
+    }
+    if (min !== undefined) return `${type} ${minExclusive ? ">" : "≥"} ${min}`;
+    if (max !== undefined) return `${type} ${maxExclusive ? "<" : "≤"} ${max}`;
     return type;
 }
 

--- a/src/common/errors/EvaluatorNumberRangeError.ts
+++ b/src/common/errors/EvaluatorNumberRangeError.ts
@@ -1,29 +1,31 @@
 import { EvaluatorParameterTypeError } from "./EvaluatorParameterTypeError";
 
 export interface NumberRangeOptions {
-    /** Minimum allowable value. Inclusive unless `minExclusive` is set. Omit to not perform a minimum check. */
+    /** Minimum allowable value (inclusive). Omit to not perform a minimum check. Ignored if `minExclusive` is set. */
     min?: number;
-    /** Maximum allowable value. Inclusive unless `maxExclusive` is set. Omit to not perform a maximum check. */
+    /** Maximum allowable value (inclusive). Omit to not perform a maximum check. Ignored if `maxExclusive` is set. */
     max?: number;
-    /** `false` by default. Set to `true` to reject `value === min`. Has no effect if `min` is omitted. */
-    minExclusive?: boolean;
-    /** `false` by default. Set to `true` to reject `value === max`. Has no effect if `max` is omitted. */
-    maxExclusive?: boolean;
+    /** Minimum allowable value (exclusive) - rejects `value === minExclusive`. Takes precedence over `min` if both are set. */
+    minExclusive?: number;
+    /** Maximum allowable value (exclusive) - rejects `value === maxExclusive`. Takes precedence over `max` if both are set. */
+    maxExclusive?: number;
     /** `true` by default. Set to `false` to allow non-integer values. */
     integer?: boolean;
 }
 
 function describeNumberRange(options: NumberRangeOptions | string): string {
     if (typeof options === "string") return options;
-    const { min, max, minExclusive = false, maxExclusive = false, integer = true } = options;
+    const { min, max, minExclusive, maxExclusive, integer = true } = options;
     const type = integer ? "integer" : "number";
-    if (min !== undefined && max !== undefined) {
-        const open = minExclusive ? "(" : "[";
-        const close = maxExclusive ? ")" : "]";
-        return `${type} ∈ ${open}${min}, ${max}${close}`;
+    const lo = minExclusive ?? min;
+    const hi = maxExclusive ?? max;
+    if (lo !== undefined && hi !== undefined) {
+        const open = minExclusive !== undefined ? "(" : "[";
+        const close = maxExclusive !== undefined ? ")" : "]";
+        return `${type} ∈ ${open}${lo}, ${hi}${close}`;
     }
-    if (min !== undefined) return `${type} ${minExclusive ? ">" : "≥"} ${min}`;
-    if (max !== undefined) return `${type} ${maxExclusive ? "<" : "≤"} ${max}`;
+    if (lo !== undefined) return `${type} ${minExclusive !== undefined ? ">" : "≥"} ${lo}`;
+    if (hi !== undefined) return `${type} ${maxExclusive !== undefined ? "<" : "≤"} ${hi}`;
     return type;
 }
 

--- a/src/common/util/numberValidation.ts
+++ b/src/common/util/numberValidation.ts
@@ -6,7 +6,19 @@ import type { NumberRangeOptions } from "../errors/EvaluatorNumberRangeError";
  * `min`/`max` are inclusive unless `minExclusive`/`maxExclusive` are set. `integer` is `true`
  * by default; set to `false` to allow non-integer values.
  */
-export function isNumberWithinRange(value: unknown, options: NumberRangeOptions = {}): value is number {
+export function isNumberWithinRange(value: unknown, options?: NumberRangeOptions): value is number;
+/** @deprecated Pass a {@link NumberRangeOptions} object instead - this positional form only exists for callers written before that option existed. */
+export function isNumberWithinRange(value: unknown, min?: number, max?: number, integer?: boolean): value is number;
+export function isNumberWithinRange(
+    value: unknown,
+    minOrOptions?: number | NumberRangeOptions,
+    legacyMax?: number,
+    legacyInteger?: boolean,
+): value is number {
+    const options: NumberRangeOptions =
+        typeof minOrOptions === "number" || minOrOptions === undefined
+            ? { min: minOrOptions, max: legacyMax, integer: legacyInteger }
+            : minOrOptions;
     const { min, max, minExclusive = false, maxExclusive = false, integer = true } = options;
     if (typeof value !== "number" || Number.isNaN(value)) return false;
     if (integer && !Number.isInteger(value)) return false;
@@ -20,7 +32,21 @@ export function isNumberWithinRange(value: unknown, options: NumberRangeOptions 
  * {@link EvaluatorNumberRangeError} otherwise.
  * @param funcName The name of the function performing the check, used in the error message.
  */
-export function assertNumberWithinRange(value: unknown, funcName: string, options: NumberRangeOptions & { paramName?: string } = {}): asserts value is number {
+export function assertNumberWithinRange(value: unknown, funcName: string, options?: NumberRangeOptions & { paramName?: string }): asserts value is number;
+/** @deprecated Pass a {@link NumberRangeOptions} object instead - this positional form only exists for callers written before that option existed. */
+export function assertNumberWithinRange(value: unknown, funcName: string, min?: number, max?: number, integer?: boolean, paramName?: string): asserts value is number;
+export function assertNumberWithinRange(
+    value: unknown,
+    funcName: string,
+    minOrOptions?: number | (NumberRangeOptions & { paramName?: string }),
+    legacyMax?: number,
+    legacyInteger?: boolean,
+    legacyParamName?: string,
+): asserts value is number {
+    const options: NumberRangeOptions & { paramName?: string } =
+        typeof minOrOptions === "number" || minOrOptions === undefined
+            ? { min: minOrOptions, max: legacyMax, integer: legacyInteger, paramName: legacyParamName }
+            : minOrOptions;
     if (!isNumberWithinRange(value, options)) {
         throw new EvaluatorNumberRangeError(value, options, funcName, options.paramName);
     }

--- a/src/common/util/numberValidation.ts
+++ b/src/common/util/numberValidation.ts
@@ -19,11 +19,11 @@ export function isNumberWithinRange(
         typeof minOrOptions === "number" || minOrOptions === undefined
             ? { min: minOrOptions, max: legacyMax, integer: legacyInteger }
             : minOrOptions;
-    const { min, max, minExclusive = false, maxExclusive = false, integer = true } = options;
+    const { min, max, minExclusive, maxExclusive, integer = true } = options;
     if (typeof value !== "number" || Number.isNaN(value)) return false;
     if (integer && !Number.isInteger(value)) return false;
-    if (min !== undefined && (minExclusive ? value <= min : value < min)) return false;
-    if (max !== undefined && (maxExclusive ? value >= max : value > max)) return false;
+    if (minExclusive !== undefined ? value <= minExclusive : min !== undefined && value < min) return false;
+    if (maxExclusive !== undefined ? value >= maxExclusive : max !== undefined && value > max) return false;
     return true;
 }
 

--- a/src/common/util/numberValidation.ts
+++ b/src/common/util/numberValidation.ts
@@ -1,16 +1,17 @@
 import { EvaluatorNumberRangeError } from "../errors/EvaluatorNumberRangeError";
+import type { NumberRangeOptions } from "../errors/EvaluatorNumberRangeError";
 
 /**
  * Checks whether `value` is a number within the given range and integer constraint.
- * @param min Minimum allowable value (inclusive). Omit to not perform a minimum check.
- * @param max Maximum allowable value (inclusive). Omit to not perform a maximum check.
- * @param integer `true` by default. Set to `false` to allow non-integer values.
+ * `min`/`max` are inclusive unless `minExclusive`/`maxExclusive` are set. `integer` is `true`
+ * by default; set to `false` to allow non-integer values.
  */
-export function isNumberWithinRange(value: unknown, min?: number, max?: number, integer: boolean = true): value is number {
+export function isNumberWithinRange(value: unknown, options: NumberRangeOptions = {}): value is number {
+    const { min, max, minExclusive = false, maxExclusive = false, integer = true } = options;
     if (typeof value !== "number" || Number.isNaN(value)) return false;
     if (integer && !Number.isInteger(value)) return false;
-    if (min !== undefined && value < min) return false;
-    if (max !== undefined && value > max) return false;
+    if (min !== undefined && (minExclusive ? value <= min : value < min)) return false;
+    if (max !== undefined && (maxExclusive ? value >= max : value > max)) return false;
     return true;
 }
 
@@ -18,13 +19,9 @@ export function isNumberWithinRange(value: unknown, min?: number, max?: number, 
  * Asserts that `value` is a number within the given range and integer constraint, throwing
  * {@link EvaluatorNumberRangeError} otherwise.
  * @param funcName The name of the function performing the check, used in the error message.
- * @param min Minimum allowable value (inclusive). Omit to not perform a minimum check.
- * @param max Maximum allowable value (inclusive). Omit to not perform a maximum check.
- * @param integer `true` by default. Set to `false` to allow non-integer values.
- * @param paramName The name of the parameter being checked, if available.
  */
-export function assertNumberWithinRange(value: unknown, funcName: string, min?: number, max?: number, integer: boolean = true, paramName?: string): asserts value is number {
-    if (!isNumberWithinRange(value, min, max, integer)) {
-        throw new EvaluatorNumberRangeError(value, { min, max, integer }, funcName, paramName);
+export function assertNumberWithinRange(value: unknown, funcName: string, options: NumberRangeOptions & { paramName?: string } = {}): asserts value is number {
+    if (!isNumberWithinRange(value, options)) {
+        throw new EvaluatorNumberRangeError(value, options, funcName, options.paramName);
     }
 }


### PR DESCRIPTION
## Description

`isNumberWithinRange`/`assertNumberWithinRange`/`EvaluatorNumberRangeError` (#42) only supported inclusive bounds (`>=`/`<=`), so there was no way to express e.g. "must be strictly positive" without dropping the standardized message format and hand-rolling the check. Raised by LeeYi in review on source-academy/modules#791.

## What's added

- `NumberRangeOptions` gains `minExclusive`/`maxExclusive` (both `false` by default, fully backward compatible).
- Message formatting switches to `>`/`<` for exclusive bounds, and to proper interval notation (`(min, max)`, `[min, max)`, etc.) when both bounds are given with mixed inclusivity.

## Signature change

`assertNumberWithinRange`/`isNumberWithinRange` switch from a positional `(value, min?, max?, integer?, paramName?)` signature to `(value, funcName, options: NumberRangeOptions & {paramName?})` — the same `NumberRangeOptions` type `EvaluatorNumberRangeError` already takes. Two more booleans would make the positional list unwieldy, and this API has no callers yet outside modules#791 (still in review), so this is the cheapest point to make this change.

## Testing

`yarn build` passes; smoke-tested the built output:
```
f: Expected integer > 0 for x, got 0.
f: Expected integer ∈ [0, 1) for x, got 1.
f: Expected integer ∈ [0, 6] for x, got 6.
isNumberWithinRange(0, {min:0, minExclusive:true}) => false
isNumberWithinRange(0.5, {min:0, minExclusive:true, integer:false}) => true
```