### PR TITLE
Add DataType.ANY for predicate-style module method arguments

### DIFF
--- a/src/conductor/types/moduleInterface/DataType.ts
+++ b/src/conductor/types/moduleInterface/DataType.ts
@@ -28,4 +28,11 @@ export enum DataType {
 
     /** A list (either a pair or the empty list). */
     LIST = 9,
+
+    /**
+     * A value of any type - matches whatever DataType the caller actually supplies. Intended for
+     * declaring the argument types of predicates (e.g. `is_tree`) that must accept a value of any
+     * DataType and answer based on its shape, rather than throwing on a mismatched type.
+     */
+    ANY = 10,
 };

--- a/src/conductor/types/moduleInterface/ExternTypeOf.ts
+++ b/src/conductor/types/moduleInterface/ExternTypeOf.ts
@@ -16,6 +16,10 @@ type typeMap<U extends DataType> = {
     [DataType.CLOSURE]: ClosureIdentifier<U>;
     [DataType.OPAQUE]: OpaqueIdentifier;
     [DataType.LIST]: List;
+    // Unreachable in practice - TypedValue<DataType.ANY, U> is special-cased to expand to the
+    // union of all concrete TypedValues instead of ever indexing this map with DataType.ANY, but
+    // typeMap must still have an entry for every DataType member to stay soundly typed.
+    [DataType.ANY]: unknown;
 }
 
 /** Maps the Conductor DataTypes to their corresponding native types. */

--- a/src/conductor/types/moduleInterface/TypedValue.ts
+++ b/src/conductor/types/moduleInterface/TypedValue.ts
@@ -7,4 +7,4 @@ interface ITypedValue<T extends DataType, U extends DataType = DataType> {
 }
 
 // export a type instead to benefit from distributive conditional type
-export type TypedValue<T extends DataType, U extends DataType = DataType> = T extends DataType ? T extends DataType.LIST ? ITypedValue<DataType.PAIR> | ITypedValue<DataType.EMPTY_LIST> : ITypedValue<T, U> : never;
+export type TypedValue<T extends DataType, U extends DataType = DataType> = T extends DataType ? T extends DataType.LIST ? ITypedValue<DataType.PAIR> | ITypedValue<DataType.EMPTY_LIST> : T extends DataType.ANY ? TypedValue<Exclude<DataType, DataType.ANY>, U> : ITypedValue<T, U> : never;

--- a/src/conductor/util/isReferenceType.ts
+++ b/src/conductor/util/isReferenceType.ts
@@ -1,6 +1,6 @@
 import { DataType } from "../types";
 
-const lookupTable = {
+const lookupTable: Record<DataType, boolean> = {
     [DataType.VOID]: false,
     [DataType.BOOLEAN]: false,
     [DataType.NUMBER]: false,
@@ -11,6 +11,7 @@ const lookupTable = {
     [DataType.CLOSURE]: true,
     [DataType.OPAQUE]: true,
     [DataType.LIST]: true, // technically not, but easier to do this due to pair being so
+    [DataType.ANY]: false, // never a value's own type tag; only ever a declared parameter type
 }
 
 export function isReferenceType(type: DataType): boolean {

--- a/src/conductor/util/isSameType.ts
+++ b/src/conductor/util/isSameType.ts
@@ -1,8 +1,8 @@
 import { DataType } from "../types";
 
 export function isSameType(t1: DataType, t2: DataType): boolean {
-    if (t1 === DataType.ANY || t2 === DataType.ANY) return true;
     if (t1 === t2) return true;
+    if (t1 === DataType.ANY || t2 === DataType.ANY) return true;
     if (t1 === DataType.LIST && (t2 === DataType.PAIR || t2 === DataType.EMPTY_LIST)) return true;
     if (t2 === DataType.LIST && (t1 === DataType.PAIR || t1 === DataType.EMPTY_LIST)) return true;
     return false;

--- a/src/conductor/util/isSameType.ts
+++ b/src/conductor/util/isSameType.ts
@@ -1,6 +1,7 @@
 import { DataType } from "../types";
 
 export function isSameType(t1: DataType, t2: DataType): boolean {
+    if (t1 === DataType.ANY || t2 === DataType.ANY) return true;
     if (t1 === t2) return true;
     if (t1 === DataType.LIST && (t2 === DataType.PAIR || t2 === DataType.EMPTY_LIST)) return true;
     if (t2 === DataType.LIST && (t1 === DataType.PAIR || t1 === DataType.EMPTY_LIST)) return true;


### PR DESCRIPTION
## Summary
- Adds `DataType.ANY` - a value of any type, for declaring the argument types of predicates (e.g. `is_tree`) that must accept a value of any DataType and answer based on its shape rather than throwing on a mismatched type.
- `TypedValue<DataType.ANY, U>` expands to the union of all concrete `TypedValue`s, the same way `TypedValue<DataType.LIST>` already expands to `TypedValue<DataType.PAIR> | TypedValue<DataType.EMPTY_LIST>`.
- Updates `isSameType`/`isReferenceType`/`ExternTypeOf`'s lookups so `ANY` is handled explicitly instead of falling through unhandled (`isReferenceType`'s lookup table is now typed `Record<DataType, boolean>` so a missing entry is a compile error, not a latent runtime bug).

## Motivation
From source-academy/modules#790 (binary_tree's Conductor migration): `is_tree`/`is_empty_tree` are predicates that need to accept a value of *any* DataType and answer `false` rather than throw for a mismatched type - today the only way to express that in a `moduleMethod`'s signature is to omit the argument's type entirely (`@moduleMethod([], DataType.BOOLEAN)`), which doesn't actually validate arity and isn't self-documenting. @AaravMalani suggested adding a `DataType.ANY` for this, and @martin-henz confirmed `is_tree` should take one.

## Test plan
- [x] `yarn tsc --noEmit`: clean
- [x] `yarn build`: succeeds
- [ ] Adopting this in `is_tree`/`is_empty_tree` etc. is a follow-up in the `modules` repo once this is released (not done in this PR)