### PR TITLE
Add a Datatype.INTEGER type

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Note that all identifiers across data types must be unique - in other words, a r
 | void         | none\*     | The return type for functions with no return value            |
 | boolean      | JS value   |                                                               |
 | number       | JS value   | Per JS limitations, this is IEEE754 binary64 (`double` in C)  |
+| integer      | JS BigInt   | This type represents an integer construct (`int64_t` in C)\*\* |
 | const string | JS value   | Strings are immutable                                         |
 | empty list   | none\*     | The empty-list value                                          |
 | pair         | Identifier |                                                               |
@@ -118,6 +119,9 @@ Note that all identifiers across data types must be unique - in other words, a r
 though it is always better to check the data type to be retrieved using the `*_type` functions than to test for equality using the JS values.
 Currently, an equality comparison with null is required to distinguish between a `Pair` and the empty list when accepting a parameter of the type List,
 though it is hoped that an alternative can be found soon.
+
+\*\* Note that current module functions may not operate beyond the range of `-(2^53 - 1)` to `2^53 - 1` due to a lack of support for BigIntegers.
+
 
 Note that language implementations **are expected to verify that the types of arguments to external closures are correct**,
 as it is not possible for the data type to be retrieved from a raw Identifier.

--- a/src/common/util/bigintValidation.ts
+++ b/src/common/util/bigintValidation.ts
@@ -1,0 +1,37 @@
+import { EvaluatorNumberRangeError } from "../errors/EvaluatorNumberRangeError";
+
+function describeBigintRange(min?: bigint, max?: bigint): string {
+    if (min !== undefined && max !== undefined) return `integer ∈ [${min}, ${max}]`;
+    if (min !== undefined) return `integer ≥ ${min}`;
+    if (max !== undefined) return `integer ≤ ${max}`;
+    return "integer";
+}
+
+/**
+ * Checks whether `value` is a bigint within the given range. The bigint counterpart to
+ * {@link isNumberWithinRange} in numberValidation.ts, for module parameters/returns declared
+ * {@link DataType.INTEGER} rather than {@link DataType.NUMBER} - bounds are bigint rather than
+ * number so a boundary near the edge of the safe integer range doesn't itself lose precision.
+ * @param min Minimum allowable value (inclusive). Omit to not perform a minimum check.
+ * @param max Maximum allowable value (inclusive). Omit to not perform a maximum check.
+ */
+export function isBigintWithinRange(value: unknown, min?: bigint, max?: bigint): value is bigint {
+    if (typeof value !== "bigint") return false;
+    if (min !== undefined && value < min) return false;
+    if (max !== undefined && value > max) return false;
+    return true;
+}
+
+/**
+ * Asserts that `value` is a bigint within the given range, throwing
+ * {@link EvaluatorNumberRangeError} otherwise.
+ * @param funcName The name of the function performing the check, used in the error message.
+ * @param min Minimum allowable value (inclusive). Omit to not perform a minimum check.
+ * @param max Maximum allowable value (inclusive). Omit to not perform a maximum check.
+ * @param paramName The name of the parameter being checked, if available.
+ */
+export function assertBigintWithinRange(value: unknown, funcName: string, min?: bigint, max?: bigint, paramName?: string): asserts value is bigint {
+    if (!isBigintWithinRange(value, min, max)) {
+        throw new EvaluatorNumberRangeError(value, describeBigintRange(min, max), funcName, paramName);
+    }
+}

--- a/src/common/util/index.ts
+++ b/src/common/util/index.ts
@@ -1,3 +1,4 @@
+export { assertBigintWithinRange, isBigintWithinRange } from "./bigintValidation";
 export { assertFunctionOfLength, isFunctionOfLength } from "./functionValidation";
 export { importExternalModule } from "./importExternalModule";
 export { importExternalPlugin } from "./importExternalPlugin";

--- a/src/conductor/types/moduleInterface/DataType.ts
+++ b/src/conductor/types/moduleInterface/DataType.ts
@@ -35,7 +35,7 @@ export enum DataType {
      * DataType and answer based on its shape, rather than throwing on a mismatched type.
      */
     ANY = 10,
-        
+
     /** An integer value. */
     INTEGER = 11,
 };

--- a/src/conductor/types/moduleInterface/DataType.ts
+++ b/src/conductor/types/moduleInterface/DataType.ts
@@ -28,4 +28,10 @@ export enum DataType {
 
     /** A list (either a pair or the empty list). */
     LIST = 9,
+
+    /** An integer value. */
+    INTEGER = 10,
+
+    /** A type that can represent any value. */
+    ANY = 11
 };

--- a/src/conductor/types/moduleInterface/ExternTypeOf.ts
+++ b/src/conductor/types/moduleInterface/ExternTypeOf.ts
@@ -16,6 +16,8 @@ type typeMap<U extends DataType> = {
     [DataType.CLOSURE]: ClosureIdentifier<U>;
     [DataType.OPAQUE]: OpaqueIdentifier;
     [DataType.LIST]: List;
+    [DataType.INTEGER]: bigint;
+    [DataType.ANY]: unknown;
 }
 
 /** Maps the Conductor DataTypes to their corresponding native types. */

--- a/src/conductor/types/moduleInterface/TypedValue.ts
+++ b/src/conductor/types/moduleInterface/TypedValue.ts
@@ -7,4 +7,4 @@ interface ITypedValue<T extends DataType, U extends DataType = DataType> {
 }
 
 // export a type instead to benefit from distributive conditional type
-export type TypedValue<T extends DataType, U extends DataType = DataType> = T extends DataType ? T extends DataType.LIST ? ITypedValue<DataType.PAIR> | ITypedValue<DataType.EMPTY_LIST> : ITypedValue<T, U> : never;
+export type TypedValue<T extends DataType, U extends DataType = DataType> = T extends DataType ? T extends DataType.LIST ? ITypedValue<DataType.PAIR> | ITypedValue<DataType.EMPTY_LIST> : T extends DataType.ANY ? ITypedValue<DataType, U> : ITypedValue<T, U> : never;

--- a/src/conductor/util/index.ts
+++ b/src/conductor/util/index.ts
@@ -4,6 +4,7 @@ export { mArray } from "./mArray";
 export { mBoolean } from "./mBoolean";
 export { mClosure } from "./mClosure";
 export { mEmptyList } from "./mEmptyList";
+export { mInteger } from "./mInteger";
 export { mNumber } from "./mNumber";
 export { mOpaque } from "./mOpaque";
 export { mPair } from "./mPair";

--- a/src/conductor/util/mInteger.ts
+++ b/src/conductor/util/mInteger.ts
@@ -1,0 +1,8 @@
+import { DataType, type TypedValue } from "../types";
+
+export function mInteger(value: bigint): TypedValue<DataType.INTEGER> {
+    return {
+        type: DataType.INTEGER,
+        value
+    };
+}


### PR DESCRIPTION
This PR adds the integer type to differentiate integers and floats for evaluators which distinguish the two types (Python, C, etc.)