### PR TITLE
feat: add array_from and allow exportable values

### DIFF
--- a/src/conductor/module/BaseModulePlugin.ts
+++ b/src/conductor/module/BaseModulePlugin.ts
@@ -1,7 +1,7 @@
 import { ConductorInternalError } from "../../common/errors";
 import { checkIsPluginClass, type IConduit, type IChannel } from "../../conduit";
 import type { IInterfacableEvaluator } from "../runner";
-import type { IDataHandler, ExternCallable, IFunctionSignature } from "../types";
+import type { IDataHandler, ExternCallable, IFunctionSignature, TypedValue, DataType } from "../types";
 import type { IModulePlugin, IModuleExport } from "./types";
 
 @checkIsPluginClass
@@ -19,7 +19,17 @@ export abstract class BaseModulePlugin implements IModulePlugin {
 
     async initialise() {
         for (const name of this.exportedNames) {
-            const m = this[name] as ExternCallable<any, any> & {signature?: IFunctionSignature<any, any>};
+            const m = this[name] as (ExternCallable<any, any> & {signature?: IFunctionSignature<any, any>}) | TypedValue<DataType>;
+            if (typeof name !== "string") throw new ConductorInternalError(`'${String(name)}' is not an exportable value`);
+            if ("type" in m) {
+                // If the exported member is a TypedValue, we can export it directly without needing to wrap it in a closure.
+                this.exports.push({
+                    symbol: name,
+                    value: m,
+                });    
+                return;
+            }
+            
             if (!m.signature || typeof m !== "function" || typeof name !== "string") throw new ConductorInternalError(`'${String(name)}' is not an exportable method`);
             // Evaluators invoke the registered closure as a bare function (e.g.
             // `closure.func(...args)`), so `m` must be bound to this instance here —

--- a/src/conductor/module/BaseModulePlugin.ts
+++ b/src/conductor/module/BaseModulePlugin.ts
@@ -27,7 +27,7 @@ export abstract class BaseModulePlugin implements IModulePlugin {
                     symbol: name,
                     value: m,
                 });    
-                return;
+                continue;
             }
             
             if (!m.signature || typeof m !== "function" || typeof name !== "string") throw new ConductorInternalError(`'${String(name)}' is not an exportable method`);

--- a/src/conductor/types/moduleInterface/IDataHandler.ts
+++ b/src/conductor/types/moduleInterface/IDataHandler.ts
@@ -65,6 +65,16 @@ export interface IDataHandler {
     array_make<T extends DataType>(t: T, len: number, init?: TypedValue<NoInfer<T>>): Promise<TypedValue<DataType.ARRAY, NoInfer<T>>>;
 
     /**
+     * Creates a new Array from an existing set of elements.    
+     * 
+     * Creation of untyped arrays (with type `VOID`) should be avoided.
+     * @param t The type of the elements of the Array.
+     * @param elements An array of typed values to be the elements of the Array.
+     * @returns A promise to a typed value to the new Array.
+     */
+    array_from<T extends DataType>(t: T, elements: TypedValue<NoInfer<T>>[]): Promise<TypedValue<DataType.ARRAY, NoInfer<T>>>;
+
+    /**
      * Gets the length of an Array.
      * @param a The Array to retrieve the length of.
      * @returns A promise to the length of the given Array.


### PR DESCRIPTION
This PR adds the `array_from<T extends DataType>` function which accepts an array of `TypedValue<T>` to increase efficiency over calling `array_set` multiple times (relevant PR, source-academy/modules#792)

It also allows Conductor constants to be exported by the `initialise` function.