### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceacademy/conductor",
   "packageManager": "yarn@4.10.3",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
The \`0.7.2\` GitHub release/tag (cut from #47, DataType.INTEGER) was created without bumping \`package.json\`'s \`version\` field — it's still \`0.7.1\` on \`main\`, so nothing can actually be published to npm as \`0.7.2\`. This just fixes the version field so the release can be published for real.