### PR TITLE
BasicEvaluator: defer RunnerStatus.STOPPED until pending async work settles

### DIFF
--- a/src/conductor/runner/BasicEvaluator.ts
+++ b/src/conductor/runner/BasicEvaluator.ts
@@ -5,6 +5,51 @@ import type { IEvaluator, IRunnerPlugin } from "./types";
 export abstract class BasicEvaluator implements IEvaluator {
     readonly conductor: IRunnerPlugin;
 
+    /**
+     * Outstanding units of async work an evaluator has told us about via beginPendingWork() and
+     * not yet matched with endPendingWork() - e.g. a scheduled real-time callback (Python's
+     * set_timeout) that may still run well after evaluateChunk()'s own promise has resolved.
+     * RunnerStatus.STOPPED is withheld while this is nonzero, since "STOPPED" means "the
+     * environment is no longer valid" (see RunnerStatus's own doc comment) - sending it while an
+     * evaluator itself knows more of its own code may still run is a lie the host has no way to
+     * detect, and it terminates the runner (host-side convention, e.g. Source Academy's frontend)
+     * out from under that still-pending work.
+     */
+    private pendingWork = 0;
+    private onPendingWorkSettled: (() => void) | null = null;
+
+    /**
+     * Registers one unit of outstanding async work, deferring RunnerStatus.STOPPED until a
+     * matching endPendingWork() call (or more precisely, until every such call this evaluator has
+     * made is matched - nesting/rescheduling is fine either way round: a callback that begins new
+     * pending work *before* matching its own, or one that matches its own first and only then
+     * begins the next (e.g. a timeout rescheduling itself from inside its fired callback), both
+     * keep STOPPED withheld correctly - see the re-checking loop in startEvaluator, which is what
+     * actually makes the latter ordering safe despite the count briefly touching zero).
+     */
+    protected beginPendingWork(): void {
+        this.pendingWork++;
+    }
+
+    /** Matches a prior beginPendingWork() call. See its doc comment for nesting semantics. */
+    protected endPendingWork(): void {
+        this.pendingWork--;
+        if (this.pendingWork === 0) {
+            this.onPendingWorkSettled?.();
+            this.onPendingWorkSettled = null;
+        }
+    }
+
+    /** Resolves the next time pendingWork returns to 0 (or immediately, if already 0 right now) -
+     * a single edge, not a guarantee it's still 0 by the time the caller wakes up and checks again
+     * (see startEvaluator's re-checking loop, which is what actually closes that gap). */
+    private nextPendingWorkSettled(): Promise<void> {
+        if (this.pendingWork === 0) return Promise.resolve();
+        return new Promise(resolve => {
+            this.onPendingWorkSettled = resolve;
+        });
+    }
+
     async startEvaluator(entryPoint: string): Promise<void> {
         try {
             const initialChunk = await this.conductor.requestFile(entryPoint);
@@ -14,6 +59,13 @@ export abstract class BasicEvaluator implements IEvaluator {
             // Always notify the host so it can unblock its own REPL loop.
             this.conductor.updateStatus(RunnerStatus.ERROR, true);
             throw e;
+        }
+        // A settled wait only proves pendingWork *touched* 0 at some past instant - a callback
+        // that matches its own pending work and then immediately begins the next unit (e.g.
+        // rescheduling itself) can slip a new beginPendingWork() in before this ever wakes up and
+        // looks again, so re-check rather than trust a single wait.
+        while (this.pendingWork > 0) {
+            await this.nextPendingWorkSettled();
         }
         this.conductor.updateStatus(RunnerStatus.STOPPED, true);
     }

--- a/src/conductor/runner/BasicEvaluator.ts
+++ b/src/conductor/runner/BasicEvaluator.ts
@@ -33,6 +33,9 @@ export abstract class BasicEvaluator implements IEvaluator {
 
     /** Matches a prior beginPendingWork() call. See its doc comment for nesting semantics. */
     protected endPendingWork(): void {
+        if (this.pendingWork === 0) {
+            throw new ConductorInternalError("endPendingWork() called without a matching beginPendingWork()");
+        }
         this.pendingWork--;
         if (this.pendingWork === 0) {
             this.onPendingWorkSettled?.();


### PR DESCRIPTION
## Summary
`startEvaluator()` reported `RunnerStatus.STOPPED` the instant `evaluateChunk()`'s promise resolved, with no way for an evaluator to say "some of my own code may still run later" — e.g. Python's `set_timeout` (source-academy/py-slang#311), which schedules a real callback well after the chunk that called it has returned.

Hosts treat `STOPPED` as "the environment is no longer valid" (see `RunnerStatus`'s own doc comment) and tear the runner down accordingly. Source Academy's frontend does this ~50ms after `STOPPED`, to drain in-flight `result`/`error`/`output` messages that raced the terminal status on their own MessagePorts — but that 50ms has nothing to do with a *future* callback the evaluator itself scheduled. The result (source-academy/py-slang#329): `set_timeout` fires reliably under ~46ms, is unreliable right at that boundary, and silently never fires at 50ms+, because the host kills the Worker mid-timer.

## Change
- `beginPendingWork()`/`endPendingWork()`: a `BasicEvaluator` subclass (or a runtime it wraps) registers outstanding async work with these. `startEvaluator` now withholds `STOPPED` until the count returns to zero.
- Re-checks in a loop rather than trusting a single wait: a callback that matches its own pending work and then immediately begins the next unit (e.g. rescheduling itself, `set_timeout` calling `set_timeout` again) can slip a new `beginPendingWork()` in before a one-shot wait would ever wake up and look again — an actual race I hit and fixed while writing the verification below, not a hypothetical.
- No pending-work calls means no behavior change: `STOPPED` still fires immediately once `evaluateChunk()` resolves, exactly as before, for every existing evaluator (CSE, PVML, WASM, Pyodide) that never calls `beginPendingWork()`.

## Test plan
This repo has no test framework configured yet, so verified directly against `src/` with throwaway `tsx` scripts covering:
- [x] No pending work at all → `STOPPED` sent immediately (t≈0ms) — confirms zero regression for existing evaluators.
- [x] A single unit of pending work (mirrors `set_timeout(f, 30)`) → `STOPPED` correctly withheld until it clears (t≈33ms, after the work, not at t=0).
- [x] A chain that reschedules itself 4 times (20ms apart) → `STOPPED` correctly withheld across every handoff (t≈84ms) — this is the case that caught the one-shot-wait race above; failed before the loop fix, passes after.

Downstream: py-slang's own fix (wiring `Py2JsRuntime`'s `set_timeout`/`clear_all_timeout` to these hooks via `Py2JsEvaluator.ts`) is written and verified against a local build of this branch; it'll go up as its own PR once this is merged and published, with a normal dependency version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V