### PR TITLE
feat: Make `hostLoadPlugin` async

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceacademy/conductor",
   "packageManager": "yarn@4.10.3",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -37,7 +37,7 @@ export abstract class BasicHostPlugin implements IHostPlugin {
 
     abstract requestFile(fileName: string): Promise<string | undefined>;
 
-    abstract requestLoadPlugin(pluginId: string): void;
+    abstract requestLoadPlugin(pluginId: string): Promise<void>;
 
     abstract queryPluginResolutions(pluginId: string): Record<string, string>;
 
@@ -113,7 +113,7 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         resultChannel?.subscribe((resultMessage: IResultMessage) => this.receiveResult?.(resultMessage.result));
 
         makeRpc<IHostPluginRpc, {}>(pluginChannel, {
-            $requestLoadPlugin: this.requestLoadPlugin.bind(this),
+            requestLoadPlugin: this.requestLoadPlugin.bind(this),
             queryPluginResolutions: this.queryPluginResolutions.bind(this)
         });
 

--- a/src/conductor/host/types/IHostPlugin.ts
+++ b/src/conductor/host/types/IHostPlugin.ts
@@ -14,7 +14,7 @@ export interface IHostPlugin extends IPlugin {
      * Request to load a plugin.
      * @param pluginId The ID of the plugin to request loading.
      */
-    requestLoadPlugin(pluginId: string): void;
+    requestLoadPlugin(pluginId: string): Promise<void>;
 
     /**
      * Queries for plugin resolutions.

--- a/src/conductor/host/types/IHostPluginRpc.ts
+++ b/src/conductor/host/types/IHostPluginRpc.ts
@@ -1,4 +1,4 @@
 export interface IHostPluginRpc {
-    $requestLoadPlugin(pluginId: string): void;
+    requestLoadPlugin(pluginId: string): void;
     queryPluginResolutions(pluginId: string): Record<string, string>;
 }

--- a/src/conductor/runner/RunnerPlugin.ts
+++ b/src/conductor/runner/RunnerPlugin.ts
@@ -88,8 +88,8 @@ export class RunnerPlugin implements IRunnerPlugin {
         this.__statusChannel.send({ status, isActive });
     }
 
-    hostLoadPlugin(pluginId: string): void {
-        this.__pluginRpc.$requestLoadPlugin(pluginId);
+    async hostLoadPlugin(pluginId: string): Promise<void> {
+        await this.__pluginRpc.requestLoadPlugin(pluginId);
     }
 
     async hostQueryPluginResolutions(pluginId: string): Promise<Record<string, string>> {

--- a/src/conductor/runner/types/IRunnerPlugin.ts
+++ b/src/conductor/runner/types/IRunnerPlugin.ts
@@ -59,7 +59,7 @@ export interface IRunnerPlugin extends IPlugin {
      * Informs the host to load a plugin.
      * @param pluginId The ID of the plugin to load.
      */
-    hostLoadPlugin(pluginId: string): void;
+    hostLoadPlugin(pluginId: string): Promise<void>;
 
     /**
      * Queries the host for plugin resolutions.


### PR DESCRIPTION
This PR makes the `hostLoadPlugin` function async. Priorly, the RPC procedure `requestLoadPlugin` was the notification `$requestLoadPlugin`.

However, for large tabs (`plotly`, etc.), it would be more efficient to wait for the tab to load before sending data over.

