### PR TITLE
Preserve a moduleMethod's .sync twin through BaseModulePlugin.initialise()

### DIFF
--- a/src/conductor/module/BaseModulePlugin.ts
+++ b/src/conductor/module/BaseModulePlugin.ts
@@ -1,8 +1,21 @@
 import { ConductorInternalError } from "../../common/errors";
 import { checkIsPluginClass, type IConduit, type IChannel } from "../../conduit";
 import type { IInterfacableEvaluator } from "../runner";
-import type { IDataHandler, ExternCallable, IFunctionSignature } from "../types";
+import type { DataType, IDataHandler, ExternCallable, IFunctionSignature, TypedValue } from "../types";
 import type { IModulePlugin, IModuleExport } from "./types";
+
+/** An `ExternCallable` that may additionally carry a `.sync` escape hatch: a plain
+ * function computing the same result with no Promise/generator indirection at all.
+ * `IDataHandler.closure_call_sync` (implemented per-evaluator, e.g. py-slang's
+ * `GenericDataHandler`) looks for this on any registered closure - module-exported
+ * or cadet-authored alike, since both are registered via the same `closure_make`
+ * call - and uses it to skip the mandatory async-generator shape entirely. A module
+ * method should only set `.sync` when it can prove the call never needs a real host
+ * round-trip (e.g. a pure read/write against an in-memory buffer). */
+type SyncCallable<Arg extends readonly DataType[], Ret extends DataType> = ExternCallable<Arg, Ret> & {
+    signature?: IFunctionSignature<Arg, Ret>;
+    sync?: (...args: TypedValue<DataType>[]) => TypedValue<DataType> | undefined;
+};
 
 @checkIsPluginClass
 export abstract class BaseModulePlugin implements IModulePlugin {
@@ -19,13 +32,22 @@ export abstract class BaseModulePlugin implements IModulePlugin {
 
     async initialise() {
         for (const name of this.exportedNames) {
-            const m = this[name] as ExternCallable<any, any> & {signature?: IFunctionSignature<any, any>};
+            const m = this[name] as SyncCallable<any, any>;
             if (!m.signature || typeof m !== "function" || typeof name !== "string") throw new ConductorInternalError(`'${String(name)}' is not an exportable method`);
             // Evaluators invoke the registered closure as a bare function (e.g.
             // `closure.func(...args)`), so `m` must be bound to this instance here —
             // otherwise `this` inside the method body is undefined the moment it's called.
             const boundMethod = m.bind(this) as typeof m;
             boundMethod.signature = m.signature;
+            // `Function.prototype.bind` only copies the call behaviour, not arbitrary
+            // properties - an optional `.sync` twin (see SyncCallable above) needs the
+            // same explicit carry-over `.signature` already gets, and the same `bind`
+            // treatment, since it may equally reference `this`. Without this, a
+            // module's `.sync` fast path would be silently dropped here before
+            // `closure_make` ever sees it, defeating `closure_call_sync` for module
+            // methods specifically (cadet-authored closures given to a module are
+            // unaffected - they're never routed through this rebind).
+            if (m.sync) boundMethod.sync = m.sync.bind(this);
             const c = await this.evaluator.closure_make(m.signature, boundMethod);
             this.exports.push({
                 symbol: name,


### PR DESCRIPTION
## Summary

`BaseModulePlugin.initialise()` registers every `@moduleMethod` via `evaluator.closure_make(signature, boundMethod)` — the same call a module uses to register a cadet-authored closure it wants to call back into. Both end up in the evaluator's `closureMap` as the identical shape, and `IDataHandler.closure_call_sync` (implemented per-evaluator, e.g. py-slang's `GenericDataHandler`) already looks up `.sync` on *any* registered closure generically — it doesn't distinguish module-exported from cadet-authored.

The one thing missing: `Function.prototype.bind()` only copies call behaviour, not arbitrary properties, so a `.sync` twin attached to a module method's bound function was being silently dropped before `closure_make` ever saw it. `.signature` survives today only because `initialise()` explicitly re-assigns it after `bind()` — this does the same for an optional `.sync`.

This makes the module→cadet direction symmetric with the cadet→module direction, where a closure crossing *into* a module already gets its `.sync` fast path preserved (see py-slang's `pythonToModule`).

## Motivation

Prompted by planning the `pix_n_flix` module's migration to Conductor ([source-academy/modules](https://github.com/source-academy/modules)). A redesigned pixel API (`get_pixel_value`/`set_pixel_value` over an opaque image handle, rather than decomposing every video frame into a Source-level array) needs to be called from inside the student's filter at high frequency — up to `width * height * 8` times per frame. Every such call crosses the mandatory `AsyncGenerator`-shaped `ExternCallable` boundary; py-slang's own py2js benchmark puts that at ~390-420ns/call vs. ~15-20ns/call for a plain synchronous call (~20x) — the difference between a usable frame budget and roughly 2.5fps at 400x300.

This is the same class of problem `closure_call_sync` already solves for `sound`'s per-sample wave callback (44,100 calls/sec) — just the reverse direction, which turns out to need no new mechanism, only this one dropped property.

## What's still needed

This lands the conductor-side half only. The evaluator side (py-slang's py2js `moduleToPython`, which today unconditionally builds an `asyncOnly` cadet-callable function for any module closure and never attempts `closure_call_sync`) needs a symmetric change to actually take advantage of a module's `.sync` twin at a call site. That's being picked up separately.

## Test plan

- [x] `yarn build` succeeds; compiled `dist/conductor/module/index.js` shows the new `s.sync&&(r.sync=s.sync.bind(this))` line
- [ ] No existing test suite in this package to extend (`yarn test` is a stub) — verification is via the downstream py-slang/modules change once that lands