### PR TITLE
Add sentCount to terminal STATUS messages for delivery-confirmed teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceacademy/conductor",
   "packageManager": "yarn@4.10.3",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -63,7 +63,7 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         return this.__status.get(status) ?? false;
     }
 
-    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean): void;
+    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean, sentCount: number): void;
 
     receiveResult?(result: any): void;
 
@@ -105,9 +105,9 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         errorChannel.subscribe((errorMessage: IErrorMessage) => this.receiveError?.(errorMessage.error));
 
         statusChannel.subscribe((statusMessage: IStatusMessage) => {
-            const {status, isActive} = statusMessage;
+            const {status, isActive, sentCount} = statusMessage;
             this.__status.set(status, isActive);
-            this.receiveStatusUpdate?.(status, isActive);
+            this.receiveStatusUpdate?.(status, isActive, sentCount);
         });
 
         resultChannel?.subscribe((resultMessage: IResultMessage) => this.receiveResult?.(resultMessage.result));

--- a/src/conductor/host/types/IHostPlugin.ts
+++ b/src/conductor/host/types/IHostPlugin.ts
@@ -94,8 +94,11 @@ export interface IHostPlugin extends IPlugin {
      * An event handler called when a status update is received.
      * @param message The status update received.
      * @param isActive Is the specified status currently active?
+     * @param sentCount How many sendOutput/sendResult/sendError messages the runner had sent as
+     * of this status update (see IStatusMessage) — lets a host wait for actual delivery of
+     * everything sent before a terminal STOPPED/ERROR, rather than guessing with a fixed delay.
      */
-    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean): void;
+    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean, sentCount: number): void;
 
     /**
      * An event handler called when an evaluation result is received.

--- a/src/conductor/runner/RunnerPlugin.ts
+++ b/src/conductor/runner/RunnerPlugin.ts
@@ -72,20 +72,31 @@ export class RunnerPlugin implements IRunnerPlugin {
         return out?.message;
     }
 
+    /**
+     * Counts sendOutput/sendResult/sendError calls, stamped onto the next status update as
+     * sentCount (see IStatusMessage) so the host can wait for its own received count to catch up
+     * before treating a terminal STOPPED/ERROR as safe to act on — output/result/error each ride
+     * their own MessagePort with no cross-channel ordering guarantee relative to STATUS.
+     */
+    private __sentCount: number = 0;
+
     sendOutput(message: string): void {
+        this.__sentCount++;
         this.__ioQueue.send({ message });
     }
 
     sendResult(result: any): void {
+        this.__sentCount++;
         this.__resultChannel.send({ result });
     }
 
     sendError(error: ConductorError): void {
+        this.__sentCount++;
         this.__errorChannel.send({ error });
     }
 
     updateStatus(status: RunnerStatus, isActive: boolean): void {
-        this.__statusChannel.send({ status, isActive });
+        this.__statusChannel.send({ status, isActive, sentCount: this.__sentCount });
     }
 
     async hostLoadPlugin(pluginId: string): Promise<void> {

--- a/src/conductor/types/IStatusMessage.ts
+++ b/src/conductor/types/IStatusMessage.ts
@@ -3,4 +3,14 @@ import type { RunnerStatus } from "./RunnerStatus";
 export interface IStatusMessage {
     status: RunnerStatus;
     isActive: boolean;
+
+    /**
+     * How many sendOutput/sendResult/sendError messages the runner has sent so far, as of this
+     * status update. Each conductor channel is its own MessagePort with no cross-channel delivery
+     * ordering guarantee, so a STATUS message can be processed by the host before content sent
+     * earlier on a different channel — this lets the host wait for its own received count to
+     * reach sentCount before treating a terminal STOPPED/ERROR as safe to act on, instead of
+     * guessing with a fixed delay.
+     */
+    sentCount: number;
 }


### PR DESCRIPTION
## Summary
`sendOutput`/`sendResult`/`sendError` each ride their own `MessagePort`, with no delivery-ordering guarantee relative to `STATUS` — a host can already have processed a terminal `STOPPED`/`ERROR` before content sent just before it (on a different channel) actually arrives, losing it if the host then tears the runner down.

This became a real problem for py-slang's `set_timeout` fix (#52/py-slang#337): once a runner correctly withholds `STOPPED` until its own pending work settles, the print/result/error it sent immediately beforehand can still lose a race against delivery of `STOPPED` itself, and a host has no way to know whether it's actually safe to act on `STOPPED` yet.

## Fix
`RunnerPlugin` now counts every `sendOutput`/`sendResult`/`sendError` call and stamps the running total onto `STATUS` as `sentCount` (`IStatusMessage`), forwarded through `BasicHostPlugin.receiveStatusUpdate`. A host can compare its own received-message count against `sentCount` and wait for genuine parity before tearing anything down, instead of guessing with a fixed delay.

Purely additive — `sentCount` is a new field on an existing message, and `receiveStatusUpdate` gains a new trailing parameter that unmodified hosts simply ignore (no behavior change, no compile break for existing consumers).

Companion fix: source-academy/frontend#TBD (adds the receiving side of this — `evalCode.ts` waiting for `sentCount` parity before treating a run as over).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `yarn build` succeeds
- [x] Verified end-to-end against source-academy/frontend via a temporary `portal:` link (reverted, not part of this diff): full frontend suite (80 files, 681 tests) passes with this branch providing the new `sentCount` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERMXesowYB9viqeGgZE4nk