### PR TITLE
fix: make module initialisation idempotent

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "rollup -c",
     "prepare": "yarn build",
     "prepack": "yarn build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "yarn build && node --test test/*.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/src/conductor/module/BaseModulePlugin.ts
+++ b/src/conductor/module/BaseModulePlugin.ts
@@ -22,6 +22,7 @@ export abstract class BaseModulePlugin implements IModulePlugin {
     abstract id: string;
     readonly exports: IModuleExport[] = [];
     readonly exportedNames: readonly (keyof this)[] = [];
+    private __initialisation: Promise<void> | undefined;
 
     readonly evaluator: IDataHandler;
 
@@ -30,7 +31,12 @@ export abstract class BaseModulePlugin implements IModulePlugin {
         this.evaluator = evaluator;
     }
 
-    async initialise() {
+    initialise(): Promise<void> {
+        this.__initialisation ??= this.__initialise();
+        return this.__initialisation;
+    }
+
+    private async __initialise(): Promise<void> {
         for (const name of this.exportedNames) {
             const m = this[name] as SyncCallable<any, any>;
             if (!m.signature || typeof m !== "function" || typeof name !== "string") throw new ConductorInternalError(`'${String(name)}' is not an exportable method`);

--- a/test/BaseModulePlugin.test.mjs
+++ b/test/BaseModulePlugin.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BaseModulePlugin } from "../dist/conductor/module/index.js";
+import { DataType } from "../dist/conductor/types/index.js";
+
+const signature = {
+    args: [DataType.NUMBER],
+    returnType: DataType.NUMBER
+};
+
+class TestModulePlugin extends BaseModulePlugin {
+    id = "test-module";
+    exportedNames = ["identity"];
+
+    identity(value) {
+        return value;
+    }
+}
+
+TestModulePlugin.prototype.identity.signature = signature;
+
+function createDeferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+        resolve = resolvePromise;
+    });
+    return {promise, resolve};
+}
+
+test("BaseModulePlugin.initialise shares one in-flight initialisation", async () => {
+    const closureMakeCalls = [];
+    const closure = createDeferred();
+    const evaluator = {
+        async closure_make(receivedSignature, func) {
+            closureMakeCalls.push({receivedSignature, func});
+            return closure.promise;
+        }
+    };
+    const plugin = new TestModulePlugin({}, [], evaluator);
+
+    const first = plugin.initialise();
+    const second = plugin.initialise();
+    let secondSettled = false;
+    void second.then(() => {
+        secondSettled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(closureMakeCalls.length, 1);
+    assert.equal(plugin.exports.length, 0);
+    assert.equal(secondSettled, false);
+
+    closure.resolve({
+        type: DataType.CLOSURE,
+        value: {
+            func: closureMakeCalls[0].func,
+            signature
+        }
+    });
+    await Promise.all([first, second]);
+    await plugin.initialise();
+
+    assert.equal(closureMakeCalls.length, 1);
+    assert.equal(plugin.exports.length, 1);
+    assert.equal(plugin.exports[0].symbol, "identity");
+    assert.equal(plugin.exports[0].signature, signature);
+});
+
+test("BaseModulePlugin.initialise preserves a failed result without retrying partial work", async () => {
+    const expectedError = new Error("closure registration failed");
+    let closureMakeCalls = 0;
+    const evaluator = {
+        async closure_make() {
+            closureMakeCalls += 1;
+            throw expectedError;
+        }
+    };
+    const plugin = new TestModulePlugin({}, [], evaluator);
+
+    await assert.rejects(plugin.initialise(), expectedError);
+    await assert.rejects(plugin.initialise(), expectedError);
+
+    assert.equal(closureMakeCalls, 1);
+    assert.equal(plugin.exports.length, 0);
+});


### PR DESCRIPTION
## Summary
- make `BaseModulePlugin.initialise()` share one in-flight result across repeated or concurrent calls
- prevent duplicate exported closure registration after initialisation completes
- preserve the original rejection if registration fails, instead of retrying partial work or allowing a later call to resolve silently
- replace the placeholder test script with a build plus the Node built-in test runner

## Why
Repeated initialisation currently appends the same exported methods to `exports` again. A simple boolean guard prevents duplicates, but it lets a concurrent second caller resolve before the first registration has finished and turns a failed first call into a silent success on retry.

The cached Promise makes all callers observe the same completion or failure while still performing registration exactly once.

Root cause tracked in source-academy/modules#830.

## Tests
- `corepack yarn install --immutable`
- `git diff --check`
- `corepack yarn test` (build plus 2 Node tests)
  - concurrent calls wait for one in-flight registration
  - failed registration is preserved without retrying partial work
