### PR TITLE
Wire sentCount through status updates so hosts can safely drain before teardown

### DIFF
--- a/src/conductor/host/BasicHostPlugin.ts
+++ b/src/conductor/host/BasicHostPlugin.ts
@@ -63,7 +63,7 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         return this.__status.get(status) ?? false;
     }
 
-    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean): void;
+    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean, sentCount: number): void;
 
     receiveResult?(result: any): void;
 
@@ -105,9 +105,9 @@ export abstract class BasicHostPlugin implements IHostPlugin {
         errorChannel.subscribe((errorMessage: IErrorMessage) => this.receiveError?.(errorMessage.error));
 
         statusChannel.subscribe((statusMessage: IStatusMessage) => {
-            const {status, isActive} = statusMessage;
+            const {status, isActive, sentCount} = statusMessage;
             this.__status.set(status, isActive);
-            this.receiveStatusUpdate?.(status, isActive);
+            this.receiveStatusUpdate?.(status, isActive, sentCount);
         });
 
         resultChannel?.subscribe((resultMessage: IResultMessage) => this.receiveResult?.(resultMessage.result));

--- a/src/conductor/host/types/IHostPlugin.ts
+++ b/src/conductor/host/types/IHostPlugin.ts
@@ -94,8 +94,12 @@ export interface IHostPlugin extends IPlugin {
      * An event handler called when a status update is received.
      * @param message The status update received.
      * @param isActive Is the specified status currently active?
+     * @param sentCount The total number of output/result/error messages the runner has sent so
+     * far, as of this status update. A host can compare this against its own received-message
+     * count to know when it's actually safe to tear the runner down after a terminal status,
+     * instead of guessing with a fixed delay.
      */
-    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean): void;
+    receiveStatusUpdate?(status: RunnerStatus, isActive: boolean, sentCount: number): void;
 
     /**
      * An event handler called when an evaluation result is received.

--- a/src/conductor/runner/RunnerPlugin.ts
+++ b/src/conductor/runner/RunnerPlugin.ts
@@ -25,6 +25,12 @@ export class RunnerPlugin implements IRunnerPlugin {
     private readonly __statusChannel: IChannel<IStatusMessage>;
     private readonly __pluginRpc: Remote<IHostPluginRpc>;
 
+    // Counts only sendOutput/sendResult/sendError - the messages a host actually waits to drain
+    // before tearing the runner down on a terminal status. Input-request messages (on the same
+    // ioQueue as output) aren't counted: they aren't part of that drain, and requestInput already
+    // awaits the host's response directly rather than firing-and-forgetting like sendOutput does.
+    private __sentCount = 0;
+
     // @ts-expect-error TODO: figure proper way to typecheck this
     private readonly __serviceHandlers = new Map<ServiceMessageType, (message: IServiceMessage) => void>([
         [ServiceMessageType.HELLO, function helloServiceHandler(this: RunnerPlugin, message: HelloServiceMessage) {
@@ -74,18 +80,21 @@ export class RunnerPlugin implements IRunnerPlugin {
 
     sendOutput(message: string): void {
         this.__ioQueue.send({ message });
+        this.__sentCount++;
     }
 
     sendResult(result: any): void {
         this.__resultChannel.send({ result });
+        this.__sentCount++;
     }
 
     sendError(error: ConductorError): void {
         this.__errorChannel.send({ error });
+        this.__sentCount++;
     }
 
     updateStatus(status: RunnerStatus, isActive: boolean): void {
-        this.__statusChannel.send({ status, isActive });
+        this.__statusChannel.send({ status, isActive, sentCount: this.__sentCount });
     }
 
     async hostLoadPlugin(pluginId: string): Promise<void> {

--- a/src/conductor/types/IStatusMessage.ts
+++ b/src/conductor/types/IStatusMessage.ts
@@ -3,4 +3,12 @@ import type { RunnerStatus } from "./RunnerStatus";
 export interface IStatusMessage {
     status: RunnerStatus;
     isActive: boolean;
+    /**
+     * The total number of output/result/error messages the runner has sent so far, as of this
+     * status update. Lets a host wait for its own received-message count to catch up before
+     * treating a terminal status (STOPPED/ERROR) as license to tear the runner down - the status
+     * channel and the output/result/error channels are independent, so a host has no other way to
+     * know whether a message sent just before STOPPED has actually arrived yet.
+     */
+    sentCount: number;
 }


### PR DESCRIPTION
## Summary
Fixes lost output: a program printing back-to-back values (even just \`print(1); print(2)\`) can lose the last message or two once a terminal status (STOPPED/ERROR) wins whatever race lands it on the host first, ahead of a message already sent on a different channel.

\`IStatusMessage\` carried only \`{ status, isActive }\` — no way for a host to know how many output/result/error messages the runner had actually sent by the time a terminal status arrives on its own, independent \`MessagePort\`.

Source Academy's frontend already implements the **consuming** half of exactly this mechanism — \`WorkspaceSaga\`'s \`handleStatuses\` destructures a \`sentCount\` third argument from its status callback and waits for its own \`receivedCount\` to catch up before treating a run as over, specifically to avoid "guessing with a fixed delay". But with nothing on the **producing** side ever actually supplying that third argument (\`BasicHostPlugin\`'s subscription only ever called \`receiveStatusUpdate(status, isActive)` — two args), it was always \`undefined\` at the frontend. \`receivedCount.count < undefined\` is always \`false\` in JS, so that wait loop silently never ran even once — the entire mechanism was dead code, and the system fell back entirely on a flat, fixed-delay grace window.

## Fix
- \`IStatusMessage\` now carries \`sentCount: number\`.
- \`RunnerPlugin\` counts \`sendOutput\`/\`sendResult\`/\`sendError\` calls (not input-request messages — those aren't part of the drain a host waits for) and stamps the running total onto every \`updateStatus\` message.
- Threaded through \`BasicHostPlugin\`/\`IHostPlugin\`'s \`receiveStatusUpdate\` as a third argument, matching the shape the frontend already expects.

No consumer of \`updateStatus\` (\`BasicEvaluator\`, or any evaluator subclass across py-slang/js-slang/scm-slang) needs to change — the count is internal bookkeeping \`RunnerPlugin\` was always positioned to keep, not something callers need to supply.

## Verification
- [x] \`yarn build\` (rollup + \`@rollup/plugin-typescript\`) succeeds cleanly
- [x] \`yarn tsc --noEmit\` clean
- [x] Checked every other constructor/consumer of \`IStatusMessage\`/\`receiveStatusUpdate\` in this repo — \`RunnerPlugin\` is the sole producer, \`BasicHostPlugin\` the sole consumer, so this is a fully self-contained change

🤖 Generated with [Claude Code](https://claude.com/claude-code)