### PR TITLE
Expose beginPendingWork/endPendingWork to modules

### DIFF
--- a/src/conductor/runner/BasicEvaluator.ts
+++ b/src/conductor/runner/BasicEvaluator.ts
@@ -26,13 +26,21 @@ export abstract class BasicEvaluator implements IEvaluator {
      * begins the next (e.g. a timeout rescheduling itself from inside its fired callback), both
      * keep STOPPED withheld correctly - see the re-checking loop in startEvaluator, which is what
      * actually makes the latter ordering safe despite the count briefly touching zero).
+     *
+     * Public (not just usable by the evaluator itself, as set_timeout is): a module can have
+     * exactly the same shape of problem - pix_n_flix's install_filter kicks off a continuous
+     * per-frame video pipeline that, like a scheduled timeout, may still be running well after the
+     * top-level program's own synchronous code has finished. A module reaches its evaluator via
+     * the same IInterfacableEvaluator reference passed into its constructor - see
+     * source-academy/conductor#59.
      */
-    protected beginPendingWork(): void {
+    beginPendingWork(): void {
         this.pendingWork++;
     }
 
-    /** Matches a prior beginPendingWork() call. See its doc comment for nesting semantics. */
-    protected endPendingWork(): void {
+    /** Matches a prior beginPendingWork() call. See its doc comment for nesting semantics - public
+     * for the same reason beginPendingWork() is. */
+    endPendingWork(): void {
         if (this.pendingWork === 0) {
             throw new ConductorInternalError("endPendingWork() called without a matching beginPendingWork()");
         }


### PR DESCRIPTION
Implements the approach Martin described in #59: makes BasicEvaluator's beginPendingWork()/endPendingWork() public instead of protected, so a module can call them (not just the evaluator itself, which is all set_timeout needed so far).

pix_n_flix's install_filter needs exactly this - it kicks off a continuous per-frame video pipeline that, like a scheduled set_timeout callback, keeps running well after the top-level program's own synchronous code has finished. Without a way to tell the evaluator "I have ongoing work", the only option was making install_filter itself never resolve, which blocks everything after it in the same program. With this exposed, install_filter can return immediately and just call beginPendingWork() once, with a matching stop() (or a hard Stop/next-Run teardown) calling endPendingWork().

A module already receives the exact same IInterfacableEvaluator instance the evaluator itself extends (just narrowed to IDataHandler's declared type in BaseModulePlugin) - this change is purely a visibility fix, no new plumbing, no behavior change for set_timeout's existing usage.

Closes #59 (or at least unblocks it - happy to adjust based on what Martin wants here).

## Test plan
- [x] `yarn build` succeeds
- [x] Verified locally against source-academy/modules#785 (pix_n_flix) - install_filter now returns immediately and code after it runs, confirmed in a live browser test