### PR TITLE
Loop BasicEvaluator.startEvaluator over further chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceacademy/conductor",
   "packageManager": "yarn@4.10.3",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceacademy/conductor",
   "packageManager": "yarn@4.10.3",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/src/conductor/runner/BasicEvaluator.ts
+++ b/src/conductor/runner/BasicEvaluator.ts
@@ -71,14 +71,49 @@ export abstract class BasicEvaluator implements IEvaluator {
             this.conductor.updateStatus(RunnerStatus.ERROR, true);
             throw e;
         }
-        // A settled wait only proves pendingWork *touched* 0 at some past instant - a callback
-        // that matches its own pending work and then immediately begins the next unit (e.g.
-        // rescheduling itself) can slip a new beginPendingWork() in before this ever wakes up and
-        // looks again, so re-check rather than trust a single wait.
+        await this.awaitPendingWorkSettled();
+
+        // The entrypoint file is only the first chunk. A host that wants a persistent REPL
+        // session (e.g. so a later chunk can see an earlier chunk's declarations) keeps this
+        // Worker alive after the file finishes and posts further chunks via IHostPlugin.sendChunk
+        // - requestChunk() below is what actually receives them. A host that instead wants a
+        // classic one-shot run simply never calls sendChunk() and tears the Worker down itself
+        // (e.g. Terminate()); there is no separate "give up the session" protocol message, since
+        // killing the Worker already accomplishes that unconditionally.
+        //
+        // A chunk that throws does not end the loop or reach RunnerStatus.STOPPED - a single bad
+        // REPL line (e.g. a typo) must not destroy previously-declared state. evaluateChunk
+        // implementations are expected to catch and report their own errors (e.g. via
+        // conductor.sendError) and resolve normally; the catch below is a safety net for ones
+        // that don't.
+        for (;;) {
+            this.conductor.updateStatus(RunnerStatus.EVAL_READY, true);
+            const chunk = await this.conductor.requestChunk();
+            this.conductor.updateStatus(RunnerStatus.RUNNING, true);
+            try {
+                this.conductor.sendResult(await this.evaluateChunk(chunk));
+            } catch (e) {
+                console.error("Evaluator error:", e);
+                this.conductor.updateStatus(RunnerStatus.ERROR, true);
+            }
+            await this.awaitPendingWorkSettled();
+        }
+    }
+
+    /**
+     * Waits until pendingWork has settled back to 0 (e.g. a chunk's set_timeout callbacks have
+     * all fired) before startEvaluator moves on - once after the initial file, then again after
+     * every chunk the loop below evaluates.
+     *
+     * A settled wait only proves pendingWork *touched* 0 at some past instant - a callback that
+     * matches its own pending work and then immediately begins the next unit (e.g. rescheduling
+     * itself) can slip a new beginPendingWork() in before this ever wakes up and looks again, so
+     * re-check rather than trust a single wait.
+     */
+    private async awaitPendingWorkSettled(): Promise<void> {
         while (this.pendingWork > 0) {
             await this.nextPendingWorkSettled();
         }
-        this.conductor.updateStatus(RunnerStatus.STOPPED, true);
     }
 
     /**


### PR DESCRIPTION
## Summary
- `IHostPlugin.sendChunk()` / `IRunnerPlugin.requestChunk()` already exist on the wire protocol, but nothing on the runner side ever called `requestChunk()` — `BasicEvaluator.startEvaluator` evaluated the entrypoint file once, reported `STOPPED`, and was done. A host that wants a persistent session (e.g. a REPL where a later line should see an earlier line's declarations) had no way to get a second `evaluateChunk()` call into the same Worker.
- `startEvaluator` now loops: after the entrypoint file, it repeatedly awaits `requestChunk()` and calls `evaluateChunk()` again, reporting `RunnerStatus.EVAL_READY` between chunks instead of `STOPPED`. The environment stays valid until the host tears the Worker down itself — there's no new "end the session" protocol message, since killing the Worker already does that.
- A chunk that throws reports `ERROR` but does **not** end the loop, so one bad REPL line can't destroy previously-declared state. This is a safety net — `evaluateChunk` implementations (e.g. py-slang's) are expected to catch and report their own errors and resolve normally.
- Verified with a standalone smoke test against the built package (mock `IRunnerPlugin`, no browser): `x = 1` in chunk 1 is visible when chunk 2 evaluates `x`; a crashing chunk reports `ERROR` and the session survives; `STOPPED` is never sent in the happy path.

## Breaking change / rollout note
Any host that relies on receiving `STOPPED` after a normal one-shot run (Source Academy's frontend, today) needs to be updated to treat `EVAL_READY` as "this evaluation finished" **before** it bumps to a published version containing this change — otherwise its run/REPL loop will hang waiting for a `STOPPED` that no longer arrives. This lands alongside a matching frontend change; do not publish/bump independently without coordinating.

Motivated by source-academy/py-slang#359 (REPL should remember previous declarations).

## Test plan
- [x] `yarn build`
- [x] Manual smoke test against `dist/` with a mock `IRunnerPlugin`: multi-chunk persistence, error-then-recovery, no spurious `STOPPED`
- [ ] This repo has no test runner configured yet (`"test": "echo ... && exit 1"`) — worth adding one as follow-up so this has real CI coverage instead of a throwaway script